### PR TITLE
chore(server): Enable MT scheduler feature

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,6 @@ authors = ["Donovan Henry <donovanphenry@gmail.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = "0.1"
+tokio = {version = "0.1", features = ["rt-multi-thread"]}
 futures = "0.1"
 websocket = "0.22.0"


### PR DESCRIPTION
The Tokio crate needs to have the `rt-multi-thread` feature flag enabled in order to use the multi-threaded scheduler.

This change adds the required feature flag to `cargo.toml`.

Jira FG-47